### PR TITLE
Fix Deprecation to BigDecimal.new for Ruby 2.6+

### DIFF
--- a/lib/tax_cloud/responses/cart_item.rb
+++ b/lib/tax_cloud/responses/cart_item.rb
@@ -16,7 +16,7 @@ module TaxCloud #:nodoc:
       # [savon_response] SOAP response.
       def initialize(savon_response)
         self.cart_item_index = savon_response[:cart_item_index].to_i
-        self.tax_amount = BigDecimal.new(savon_response[:tax_amount])
+        self.tax_amount = BigDecimal(savon_response[:tax_amount])
       end
     end
   end


### PR DESCRIPTION
https://docs.ruby-lang.org/en/2.6.0/NEWS.html#label-Stdlib+updates+-28outstanding+ones+only-29